### PR TITLE
General: Use the 'context' namespace instead of 'contexts' in order to match the changes added in libm2k.

### DIFF
--- a/include/m2k/analog_in_converter.h
+++ b/include/m2k/analog_in_converter.h
@@ -46,7 +46,7 @@ public:
      */
     static sptr make(const std::string &uri);
 
-    static sptr make_from(libm2k::contexts::M2k *context);
+    static sptr make_from(libm2k::context::M2k *context);
 
 };
 

--- a/include/m2k/analog_out_converter.h
+++ b/include/m2k/analog_out_converter.h
@@ -46,7 +46,7 @@ public:
      */
     static sptr make(const std::string &uri);
 
-    static sptr make_from(libm2k::contexts::M2k *context);
+    static sptr make_from(libm2k::context::M2k *context);
 
 };
 

--- a/lib/analog_in_converter_impl.cc
+++ b/lib/analog_in_converter_impl.cc
@@ -38,13 +38,13 @@ analog_in_converter::make(const std::string &uri)
 }
 
 analog_in_converter::sptr
-analog_in_converter::make_from(libm2k::contexts::M2k *context)
+analog_in_converter::make_from(libm2k::context::M2k *context)
 {
     return gnuradio::get_initial_sptr
         (new analog_in_converter_impl(context));
 }
 
-analog_in_converter_impl::analog_in_converter_impl(libm2k::contexts::M2k *context)
+analog_in_converter_impl::analog_in_converter_impl(libm2k::context::M2k *context)
     : gr::sync_block("analog_in_converter",
                      gr::io_signature::make(1, 1, sizeof(short)),
                      gr::io_signature::make(1, 1, sizeof(float)))

--- a/lib/analog_in_converter_impl.h
+++ b/lib/analog_in_converter_impl.h
@@ -32,7 +32,7 @@ private:
     libm2k::analog::M2kAnalogIn *d_analog_in;
 
 public:
-    analog_in_converter_impl(libm2k::contexts::M2k *context);
+    analog_in_converter_impl(libm2k::context::M2k *context);
 
     ~analog_in_converter_impl();
 

--- a/lib/analog_in_source_impl.cc
+++ b/lib/analog_in_source_impl.cc
@@ -78,7 +78,7 @@ analog_in_source_impl::analog_in_source_impl(const std::string &uri,
     d_channels(channels),
     d_stream_voltage_values(stream_voltage_values)
 {
-    libm2k::contexts::M2k *context = analog_in_source_impl::get_context(uri);
+    libm2k::context::M2k *context = analog_in_source_impl::get_context(uri);
     d_analog_in = context->getAnalogIn();
 
     d_analog_in->setKernelBuffersCount(kernel_buffers);
@@ -137,15 +137,15 @@ void analog_in_source_impl::set_trigger(std::vector<int> trigger_condition,
     trigger->setAnalogDelay(trigger_delay);
 }
 
-libm2k::contexts::M2k *analog_in_source_impl::get_context(const std::string &uri)
+libm2k::context::M2k *analog_in_source_impl::get_context(const std::string &uri)
 {
     auto element = s_contexts.find(uri);
     if (element == s_contexts.end()) {
-        libm2k::contexts::M2k *ctx = libm2k::contexts::m2kOpen(uri.c_str());
+	libm2k::context::M2k *ctx = libm2k::context::m2kOpen(uri.c_str());
         if (ctx == nullptr) {
             throw std::runtime_error("Unable to create the context!");
         }
-        s_contexts.insert(std::pair<std::string, libm2k::contexts::M2k *>(ctx->getUri(), ctx));
+	s_contexts.insert(std::pair<std::string, libm2k::context::M2k *>(ctx->getUri(), ctx));
         return ctx;
     }
     return element->second;
@@ -156,7 +156,7 @@ void analog_in_source_impl::remove_contexts(const std::string &uri)
     boost::lock_guard <boost::mutex> lock(s_ctx_mutex);
     auto element = s_contexts.find(uri);
     if (element != s_contexts.end()) {
-        libm2k::contexts::contextClose(element->second, true);
+	libm2k::context::contextClose(element->second, true);
         s_contexts.erase(element);
     }
 }

--- a/lib/analog_in_source_impl.h
+++ b/lib/analog_in_source_impl.h
@@ -28,7 +28,7 @@
 namespace gr {
 namespace m2k {
 
-static std::map<std::string, libm2k::contexts::M2k *> s_contexts;
+static std::map<std::string, libm2k::context::M2k *> s_contexts;
 static boost::mutex s_ctx_mutex;
 
 class analog_in_source_impl : public analog_in_source {
@@ -75,7 +75,7 @@ public:
                      int trigger_delay,
                      std::vector<double> trigger_level);
 
-    static libm2k::contexts::M2k *get_context(const std::string &uri);
+    static libm2k::context::M2k *get_context(const std::string &uri);
 
     static void remove_contexts(const std::string &uri);
 };

--- a/lib/analog_out_converter_impl.cc
+++ b/lib/analog_out_converter_impl.cc
@@ -37,13 +37,13 @@ analog_out_converter::make(const std::string &uri)
 }
 
 analog_out_converter::sptr
-analog_out_converter::make_from(libm2k::contexts::M2k *context)
+analog_out_converter::make_from(libm2k::context::M2k *context)
 {
     return gnuradio::get_initial_sptr
         (new analog_out_converter_impl(context));
 }
 
-analog_out_converter_impl::analog_out_converter_impl(libm2k::contexts::M2k *context)
+analog_out_converter_impl::analog_out_converter_impl(libm2k::context::M2k *context)
     : gr::sync_block("analog_out_converter",
                      gr::io_signature::make(1, 1, sizeof(float)),
                      gr::io_signature::make(1, 1, sizeof(short)))

--- a/lib/analog_out_converter_impl.h
+++ b/lib/analog_out_converter_impl.h
@@ -32,7 +32,7 @@ private:
     libm2k::analog::M2kAnalogOut *d_analog_out;
 
 public:
-    analog_out_converter_impl(libm2k::contexts::M2k *context);
+    analog_out_converter_impl(libm2k::context::M2k *context);
 
     ~analog_out_converter_impl();
 

--- a/lib/analog_out_sink_impl.cc
+++ b/lib/analog_out_sink_impl.cc
@@ -61,7 +61,7 @@ analog_out_sink_impl::analog_out_sink_impl(const std::string &uri,
     d_buffer_size(buffer_size),
     d_stream_voltage_values(input_voltage)
 {
-    libm2k::contexts::M2k *context = analog_in_source_impl::get_context(uri);
+    libm2k::context::M2k *context = analog_in_source_impl::get_context(uri);
     d_analog_out = context->getAnalogOut();
 
     d_analog_out->stop();


### PR DESCRIPTION
Should be merged only after this PR is resolved https://github.com/analogdevicesinc/libm2k/pull/125 .

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>