### PR TITLE
Fix analog out work routine

### DIFF
--- a/lib/analog_out_sink_impl.cc
+++ b/lib/analog_out_sink_impl.cc
@@ -111,12 +111,12 @@ int analog_out_sink_impl::work(int noutput_items,
         samples.push_back(std::vector<short>());
         if (d_stream_voltage_values) {
             float *temp_samples = (float *) input_items[i];
-            for (int j = 0; j < noutput_items; j++) {
+            for (int j = 0; j < d_buffer_size; j++) {
                 samples[i].push_back(d_analog_out->convertVoltsToRaw(0, temp_samples[j]));
             }
         } else {
             short *temp_samples = (short *) input_items[i];
-            for (int j = 0; j < noutput_items; j++) {
+            for (int j = 0; j < d_buffer_size; j++) {
                 samples[i].push_back(temp_samples[j]);
             }
         }

--- a/lib/analog_out_sink_impl.h
+++ b/lib/analog_out_sink_impl.h
@@ -33,6 +33,8 @@ private:
     const std::string d_uri;
     const int d_buffer_size;
     bool d_stream_voltage_values;
+    std::vector<bool> d_cyclic_buffer;
+    bool d_first_iteration;
 
 public:
     analog_out_sink_impl(const std::string &uri,


### PR DESCRIPTION
- Push buffers of fixed size, do not assume every work call will transmit constant number of samples.
- Add cyclic mode.

Fixes #15 and #16.