### PR TITLE
python/m2k/bindings: Fix copying python bindings to directory on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 GNU Radio blocks for ADALM-2000. More information available at https://wiki.analog.com/university/tools/m2k/libm2k/gr-m2k.
 
 ## Dependencies
- - gnuradio 3.8  
+ - gnuradio 3.10
    For more information visit: https://wiki.gnuradio.org/index.php/InstallingGR
  - libm2k  
    For more information visit: https://github.com/analogdevicesinc/libm2k  

--- a/python/m2k/bindings/CMakeLists.txt
+++ b/python/m2k/bindings/CMakeLists.txt
@@ -42,11 +42,9 @@ GR_PYBIND_MAKE_OOT(m2k
    "${m2k_python_files}")
 
 # copy in bindings .so file for use in QA test module
-add_custom_target(
-  copy_bindings_for_tests ALL
-  COMMAND
-    ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/*.so"
+add_custom_command(TARGET m2k_python POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:m2k_python>
     ${CMAKE_BINARY_DIR}/test_modules/gnuradio/m2k/
-  DEPENDS m2k_python)
+)
 
 install(TARGETS m2k_python DESTINATION ${GR_PYTHON_DIR}/gnuradio/m2k COMPONENT pythonapi)


### PR DESCRIPTION


Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>